### PR TITLE
added main entry to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,5 +8,8 @@
   "dependencies": {
     "angular": "1.2.x",
     "cloudinary_js": ">=1.0.17"
-  }
+  },
+  "main": [
+    "js/angular.cloudinary.js"
+  ]
 }


### PR DESCRIPTION
Some asset managers make use of the main entry and allow easier includes.

Example: Using rails-assets.org you can do 

``` ruby
// = require cloudinary_ng
```

instead of

``` ruby
// = require cloudinary_ng/js/angular.cloudinary
```
