### PR TITLE
Change angular 1.2 requirement to angular 1.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "angular": "1.2.x",
+    "angular": "1.x",
     "cloudinary_js": ">=1.0.17"
   },
   "main": [


### PR DESCRIPTION
We are successfully using this lib with angular 1.3 on production for a while already, but this restriction caused problems on our dependency handling