### PR TITLE
Enables dynamic transformations

### DIFF
--- a/js/angular.cloudinary.js
+++ b/js/angular.cloudinary.js
@@ -70,15 +70,50 @@
           }
         });
         clImageCtrl.addTransformation(attributes);
+
+        scope.$watch(function() {
+          var output=[];
+          for(var a in attrs.$attr){
+            output.push(attrs[a]);
+          }
+          return output;
+        },function(newVal,oldVal){
+          clImageCtrl.updateTransformation(newVal,oldVal);
+        },true);
+
       }
-    }
-  }]);
+    };
+}]);
 
   angularModule.directive('clImage', [function() {
     var Controller = function($scope) {
       this.addTransformation = function(ts) {
         $scope.transformations = $scope.transformations || [];
         $scope.transformations.push(ts);
+      }
+
+      this.updateTransformation = function(newTransformation,oldTransformation) {
+        if($scope.transformations.length){
+          for(var t in $scope.transformations){
+            var equal = true;
+            var c = 0;
+            for(var i in $scope.transformations[t]){
+              if(typeof oldTransformation[c] === 'undefined'
+                || $scope.transformations[t][i] !== oldTransformation[c] ){
+                equal = false
+              }
+              c++;
+            }
+
+            if(equal){
+              var c = 0;
+              for(var i in $scope.transformations[t]){
+                $scope.transformations[t][i] = newTransformation[c];
+                c++;
+              }
+            }
+          }
+        }
       }
     };
     Controller.$inject = ['$scope'];
@@ -125,6 +160,16 @@
         } else {
           element.removeAttr("height");
         }
+        
+        scope.$watch('transformations',function(newVal,oldVal){
+
+          if (scope.transformations) {
+            attributes.transformation = scope.transformations;
+          }
+          if (!attrs.publicId) return;
+            loadImage();
+
+        },true);
 
         var loadImage = function() {
           var url = $.cloudinary.url(publicId, attributes);


### PR DESCRIPTION
I was using this library on a project that needed the transformations values to be updated dynamically. The use case was a cropper tool for a Cloudinary hosted image. When the user changes the cropper dimension the image should be modified on the fly. The original library did not had support for that , so I had to implement myself. I believe this might be useful for others in the community. 

As a result, the cl-transformation directive tag would support things like this  :
`<cl-image public-id="{{profile.avatar}}" class="avatar-image" format="jpg" ng-show="profile.avatar">
              <cl-transformation width="100" height="100" crop="fit"/>
              <cl-transformation x="{{profile.avatar_x}}" y="{{profile.avatar_y}}"
                width="{{profile.avatar_width}}" height="{{profile.avatar_height}}" crop="crop"
              />
</cl-image>`
