### PR TITLE
hotfix/fix-photo-album-assets-relative-path

### DIFF
--- a/samples/photo_album/app/index.html
+++ b/samples/photo_album/app/index.html
@@ -10,24 +10,24 @@
   <link rel="stylesheet" href="css/app.css">
   <link rel="stylesheet" href="css/animations.css">
 
-  <script src="../bower_components/jquery/dist/jquery.js"></script>
+  <script src="../vendor/assets/bower/jquery/dist/jquery.js"></script>
   <!-- jquery file upload related. only needed if jquery file upload is used -->
-  <script src="../bower_components/blueimp-file-upload/js/vendor/jquery.ui.widget.js"></script>
-  <script src="../bower_components/blueimp-file-upload/js/jquery.iframe-transport.js"></script>
-  <script src="../bower_components/blueimp-file-upload/js/jquery.fileupload.js"></script>
+  <script src="../vendor/assets/bower/blueimp-file-upload/js/vendor/jquery.ui.widget.js"></script>
+  <script src="../vendor/assets/bower/blueimp-file-upload/js/jquery.iframe-transport.js"></script>
+  <script src="../vendor/assets/bower/blueimp-file-upload/js/jquery.fileupload.js"></script>
   <!-- end jquery file upload related -->
-  <script src="../bower_components/cloudinary_js/js/jquery.cloudinary.js"></script>
+  <script src="../vendor/assets/bower/cloudinary_js/js/jquery.cloudinary.js"></script>
   <!-- angular file upload -->
-  <script src="../bower_components/ng-file-upload/angular-file-upload-shim.min.js"></script>
+  <script src="../vendor/assets/bower/ng-file-upload/angular-file-upload-shim.min.js"></script>
   <!-- angular dependencies -->
-  <script src="../bower_components/angular/angular.js"></script>
-  <script src="../bower_components/angular-animate/angular-animate.js"></script>
-  <script src="../bower_components/angular-route/angular-route.js"></script>
-  <script src="../bower_components/angular-resource/angular-resource.js"></script>
+  <script src="../vendor/assets/bower/angular/angular.js"></script>
+  <script src="../vendor/assets/bower/angular-animate/angular-animate.js"></script>
+  <script src="../vendor/assets/bower/angular-route/angular-route.js"></script>
+  <script src="../vendor/assets/bower/angular-resource/angular-resource.js"></script>
   <!-- cloudinary angular plugin -->
-  <script src="../bower_components/cloudinary_ng/js/angular.cloudinary.js"></script>
+  <script src="../vendor/assets/bower/cloudinary_ng/js/angular.cloudinary.js"></script>
   <!-- angular file upload -->
-  <script src="../bower_components/ng-file-upload/angular-file-upload.min.js"></script> 
+  <script src="../vendor/assets/bower/ng-file-upload/angular-file-upload.min.js"></script> 
   <!-- application code -->
   <script src="js/app.js"></script>
   <script src="js/config.js"></script>


### PR DESCRIPTION
When I tried the example in my machine I realized all the JS/CSS and other assets weren't loading:

```
cd samples/photo_album
npm start
...
```

I went to the browser at http://localhost:8000/app
The index.html opened file, but not the assets.
So I looked in the browser console and realized that the paths were wrong, then I replaced **bower_components** by **vendor/assets/bower** and everything worked.
