### PR TITLE
bower dependency fix for "cloudinary_ng"

### DIFF
--- a/samples/photo_album/bower.json
+++ b/samples/photo_album/bower.json
@@ -11,7 +11,7 @@
     "angular-route": "1.4.x",
     "angular-resource": "1.4.x",
     "angular-animate": "1.4.x",
-    "cloudinary_ng": "../..#master"
+    "cloudinary_ng": "#master"
   },
   "ignore": {}
 }


### PR DESCRIPTION
This was breaking when running bower install or npm start (issue #38)