### PR TITLE
Fix cloudinary_js version at 1.x to avoid 2.x breaking changes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "angular": ">=1.3.10",
-    "cloudinary_js": "1.0.25"
+    "cloudinary_js": "<=1.0.25"
   },
   "repository": {
     "type": "git",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudinary_ng",
   "description": "A set of AngularJS directives/helpers for using Cloudinary with AngularJS",
-  "version": "0.1.5",
+  "version": "0.1.4",
   "homepage": "https://github.com/cloudinary/cloudinary_angular",
   "license": "MIT",
   "private": false,

--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "angular": ">=1.3.10",
-    "cloudinary_js": "~1.0.25"
+    "cloudinary_js": "1.0.25"
   },
   "repository": {
     "type": "git",

--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "angular": ">=1.3.10",
-    "cloudinary_js": ">=1.0.17"
+    "cloudinary_js": "~1.0.25"
   },
   "repository": {
     "type": "git",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudinary_ng",
   "description": "A set of AngularJS directives/helpers for using Cloudinary with AngularJS",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "homepage": "https://github.com/cloudinary/cloudinary_angular",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
Existing semver is too liberal; it allows install of 2.x `cloudinary_js `which has breaking changes.

This changes fixes the version on 1.x so it works as expected/documented.