### PR TITLE
Update for Angular 4.0-rc2+ (ngx)

### DIFF
--- a/e2e/app.e2e-spec.ts
+++ b/e2e/app.e2e-spec.ts
@@ -2,7 +2,7 @@ const path = require('path');
 
 import { browser, element, by } from 'protractor';
 
-// Using require instead of import until clodinary-core has typings and can be loaded by tsc 
+// Using require instead of import until clodinary-core has typings and can be loaded by tsc
 // Assumes CLOUDINARY_URL environment variable is set, see https://github.com/cloudinary/cloudinary_npm
 const cloudinary = require('cloudinary');
 

--- a/package.json
+++ b/package.json
@@ -43,19 +43,20 @@
   },
   "homepage": "https://github.com/cloudinary/cloudinary_angular",
   "dependencies": {
-    "@angular/common": "^2.4.3",
-    "@angular/compiler-cli": "^2.2.4",
-    "@angular/core": "^2.4.3",
-    "@angular/platform-server": "^2.4.3",
+    "@angular/common": "^4.0.0-rc.2",
+    "@angular/compiler": "^4.0.0-rc.2",
+    "@angular/compiler-cli": "^4.0.0-rc.2",
+    "@angular/core": "^4.0.0-rc.2",
+    "@angular/platform-server": "^4.0.0-rc.2",
     "core-js": "^2.4.1",
     "reflect-metadata": "^0.1.8",
-    "rxjs": "^5.0.1",
-    "zone.js": "^0.7.2"
+    "rxjs": "^5.1.1",
+    "zone.js": "^0.7.7"
   },
   "devDependencies": {
-    "@angular/compiler": "^2.4.3",
-    "@angular/platform-browser": "^2.4.3",
-    "@angular/platform-browser-dynamic": "^2.4.3",
+    "@angular/compiler": "^4.0.0-rc.2",
+    "@angular/platform-browser": "^4.0.0-rc.2",
+    "@angular/platform-browser-dynamic": "^4.0.0-rc.2",
     "@types/jasmine": "^2.5.36",
     "@types/node": "^6.0.46",
     "@types/selenium-webdriver": "^2.53.36",
@@ -73,8 +74,8 @@
     "karma-phantomjs-launcher": "^1.0.2",
     "protractor": "^4.0.12",
     "systemjs": "^0.19.41",
-    "tslint": "^4.2.0",
-    "typescript": "^2.0.10",
+    "tslint": "~4.4.2",
+    "typescript": "~2.1.6",
     "webdriver-manager": "^10.2.10"
   }
 }

--- a/src/cloudinary.module.ts
+++ b/src/cloudinary.module.ts
@@ -1,6 +1,6 @@
 'use strict';
 /* App Module */
-import { NgModule, ModuleWithProviders, OpaqueToken } from '@angular/core';
+import { NgModule, ModuleWithProviders, InjectionToken } from '@angular/core';
 import { Cloudinary } from './cloudinary.service';
 import { CloudinaryImage } from './cloudinary-image.component';
 import { CloudinaryVideo } from './cloudinary-video.component';
@@ -18,8 +18,8 @@ export { Cloudinary, provideCloudinary } from './cloudinary.service';
 
 export { CloudinaryConfiguration };
 
-export const CLOUDINARY_LIB = new OpaqueToken('CLOUDINARY_LIB');
-export const CLOUDINARY_CONFIGURATION = new OpaqueToken('CLOUDINARY_CONFIGURATION');
+export const CLOUDINARY_LIB = new InjectionToken('CLOUDINARY_LIB');
+export const CLOUDINARY_CONFIGURATION = new InjectionToken('CLOUDINARY_CONFIGURATION');
 
 // Export this function to Angular's AOT to work
 export function createCloudinary(cloudinaryJsLib: any, configuration: any) {


### PR DESCRIPTION
Updates the angular dependency in `package.json` and removes `opaqueToken`.
See:
https://blog.thoughtram.io/angular/2016/05/23/opaque-tokens-in-angular-2
.html#injectiontoken-since-angular-4x
for more details

closes #73 
closes #74 