### PR TITLE
Add test coverage requirements

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -144,6 +144,7 @@
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
             "main": "projects/angular-cld/src/test.ts",
+            "codeCoverage": true,
             "tsConfig": "projects/angular-cld/tsconfig.spec.json",
             "karmaConfig": "projects/angular-cld/karma.conf.js"
           }

--- a/projects/angular-cld/karma.conf.js
+++ b/projects/angular-cld/karma.conf.js
@@ -19,7 +19,13 @@ module.exports = function (config) {
     coverageIstanbulReporter: {
       dir: require('path').join(__dirname, '../../coverage'),
       reports: ['html', 'lcovonly'],
-      fixWebpackSourcePaths: true
+      fixWebpackSourcePaths: true,
+      thresholds: {
+        statements: 80,
+        lines: 80,
+        branches: 80,
+        functions: 80
+      }
     },
     reporters: ['progress', 'kjhtml'],
     port: 9876,


### PR DESCRIPTION
When running npm run test will run test coverage requirements. Will fail if coverage falls under requirements