### PR TITLE
resolve errors when using lazyload and ssr

### DIFF
--- a/projects/angular-cld/src/lib/cloudinary-lazy-load.directive.ts
+++ b/projects/angular-cld/src/lib/cloudinary-lazy-load.directive.ts
@@ -1,5 +1,5 @@
 import {AfterViewInit, Directive, ElementRef} from '@angular/core';
-
+import { isBrowser } from './cloudinary.service';
 
 @Directive({
   selector: 'cl-image[loading=lazy]'
@@ -9,11 +9,13 @@ export class LazyLoadDirective implements AfterViewInit {
   constructor(private el: ElementRef) {}
 
   ngAfterViewInit() {
+    if (isBrowser()) {
       if (!this.isNativeLazyLoadSupported() && this.isLazyLoadSupported()) {
         this.lazyLoad();
       } else {
         this.loadImage();
       }
+    }
   }
 
   loadImage() {


### PR DESCRIPTION
*Errors were resolved when using SSR.
*The same approach was used for the lazy load directive as for the image component 
meaning we display an empty image tag for SSR
*In lack of SSR tests this was tested locally to ensure no errors